### PR TITLE
Discrete zoom steps on UI +/- buttons

### DIFF
--- a/GCSViews/CameraView.Designer.cs
+++ b/GCSViews/CameraView.Designer.cs
@@ -159,7 +159,7 @@
             this.btn_ZoomMinus.Name = "btn_ZoomMinus";
             this.btn_ZoomMinus.UseVisualStyleBackColor = false;
             this.btn_ZoomMinus.MouseDown += new System.Windows.Forms.MouseEventHandler(this.btn_ZoomMinus_MouseDown);
-            this.btn_ZoomMinus.MouseUp += new System.Windows.Forms.MouseEventHandler(this.btn_ZoomMinus_MouseUp);
+            this.btn_ZoomMinus.MouseUp += new System.Windows.Forms.MouseEventHandler(this.btn_Zoom_MouseUp);
             // 
             // btn_ZoomPlus
             // 
@@ -169,7 +169,7 @@
             this.btn_ZoomPlus.Name = "btn_ZoomPlus";
             this.btn_ZoomPlus.UseVisualStyleBackColor = false;
             this.btn_ZoomPlus.MouseDown += new System.Windows.Forms.MouseEventHandler(this.btn_ZoomPlus_MouseDown);
-            this.btn_ZoomPlus.MouseUp += new System.Windows.Forms.MouseEventHandler(this.btn_ZoomPlus_MouseUp);
+            this.btn_ZoomPlus.MouseUp += new System.Windows.Forms.MouseEventHandler(this.btn_Zoom_MouseUp);
             // 
             // tlp_btnsToFit
             // 

--- a/GCSViews/CameraView.cs
+++ b/GCSViews/CameraView.cs
@@ -1504,20 +1504,15 @@ namespace MissionPlanner.GCSViews
 
         private void btn_ZoomPlus_MouseDown(object sender, MouseEventArgs e)
         {
-            CameraHandler.Instance.SetZoom(ZoomState.In);
-        }
-
-        private void btn_ZoomPlus_MouseUp(object sender, MouseEventArgs e)
-        {
-            CameraHandler.Instance.SetZoom(ZoomState.Stop);
+            CameraHandler.Instance.SetZoomLevel(CameraHandler.Instance.ZoomLevel + 1);
         }
 
         private void btn_ZoomMinus_MouseDown(object sender, MouseEventArgs e)
         {
-            CameraHandler.Instance.SetZoom(ZoomState.Out);
+            CameraHandler.Instance.SetZoomLevel(CameraHandler.Instance.ZoomLevel - 1);
         }
 
-        private void btn_ZoomMinus_MouseUp(object sender, MouseEventArgs e)
+        private void btn_Zoom_MouseUp(object sender, MouseEventArgs e)
         {
             CameraHandler.Instance.SetZoom(ZoomState.Stop);
         }


### PR DESCRIPTION
- 10 zoom steps calculated for Day and IR camera range
- Steps can be changed by changing the `CameraHandler.ZoomLevels` constant
- Current zoom level is calculated from current FOV (not the last input)