### PR TITLE
Fix/joystick rc switching

### DIFF
--- a/ExtLibs/ArduPilot/Joystick/JoystickBase.cs
+++ b/ExtLibs/ArduPilot/Joystick/JoystickBase.cs
@@ -84,6 +84,18 @@ namespace MissionPlanner.Joystick
             {
                 loadconfig();
             }
+
+            // Register MV04 joystick mode switch to MAVInterface SetMode event
+            Interface.SetModeEvent += Interface_SetModeEvent;
+        }
+
+        private void Interface_SetModeEvent(object sender, SetModeEventArgs e)
+        {
+            // Interpret joystick mode
+            MV04_JoyMode joyMode = e.MV04CameraMode ? MV04_JoyMode.Camera : MV04_JoyMode.UAV;
+
+            // Do RC channel reconfig
+            MV04_SetRCChannels(joyMode);
         }
 
         public void loadconfig(string joystickconfigbuttonin = "joystickbuttons.xml",
@@ -213,7 +225,7 @@ namespace MissionPlanner.Joystick
             JoyChannels[channel].axis = axis;
         }
 
-        public void MV04_SetRCChannels(MV04_JoyFlightMode mode)
+        public void MV04_SetRCChannels(MV04_JoyMode mode)
         {
             // Change axes
             JoystickHandler.GetAxisSet(mode)
@@ -227,7 +239,7 @@ namespace MissionPlanner.Joystick
                 });
 
             // Notify
-            log.Info($"Joystick config set to {Enum.GetName(typeof(MV04_JoyFlightMode), mode)}");
+            log.Info($"Joystick config set to {Enum.GetName(typeof(MV04_JoyMode), mode)}");
             JoystickHandler.TriggerJoystickModeChangedEvent(mode);
         }
 
@@ -684,7 +696,6 @@ namespace MissionPlanner.Joystick
                                 switch ((buttonfunction_mv04_FlightMode_option)(int)Math.Round(but.p1))
                                 {
                                     case buttonfunction_mv04_FlightMode_option.Manual:
-                                        MV04_SetRCChannels(MV04_JoyFlightMode.Manual);
                                         if (Interface.MAV.cs.mode.ToLower() != "loiter")
                                             Interface.setMode((byte)Interface.sysidcurrent, (byte)Interface.compidcurrent, "Loiter");
                                         
@@ -695,32 +706,23 @@ namespace MissionPlanner.Joystick
                                         break;
                                     
                                     case buttonfunction_mv04_FlightMode_option.TapToFly:
-
-                                        #region Tap2Fly
-
-                                        MV04_SetRCChannels(MV04_JoyFlightMode.TapToFly);
-
                                         var custom_mode = (Interface.MAV.cs.sensors_enabled.motor_control && Interface.MAV.cs.sensors_enabled.seen) ? 1u : 0u;
                                         var set_mode = new MAVLink.mavlink_set_mode_t() { custom_mode = custom_mode, target_system = (byte)Interface.sysidcurrent };
 
                                         Interface.translateMode((byte)Interface.sysidcurrent, (byte)Interface.compidcurrent, "GUIDED", ref set_mode);
 
                                         Interface.setMode((byte)Interface.sysidcurrent, (byte)Interface.compidcurrent,
-                                            set_mode, MAV_MODE_FLAG.GUIDED_ENABLED);
+                                            set_mode, MAV_MODE_FLAG.GUIDED_ENABLED, true);
 
                                         StateHandler.CurrentSate = MV04_State.TapToFly;
 
                                         CameraHandler.Instance.SetMode(MavProto.NvSystemModes.Observation);
 
-                                        #endregion
-
                                         break;
                                     
                                     case buttonfunction_mv04_FlightMode_option.Auto:
-                                        MV04_SetRCChannels(MV04_JoyFlightMode.Auto);
-
                                         if (Interface.MAV.cs.mode.ToLower() != "auto")
-                                            Interface.setMode((byte)Interface.sysidcurrent, (byte)Interface.compidcurrent, "AUTO");
+                                            Interface.setMode((byte)Interface.sysidcurrent, (byte)Interface.compidcurrent, "AUTO", true);
 
                                         CameraHandler.Instance.SetMode(MavProto.NvSystemModes.Observation);
                                         
@@ -728,10 +730,8 @@ namespace MissionPlanner.Joystick
                                         break;
                                     
                                     case buttonfunction_mv04_FlightMode_option.Follow:
-                                        MV04_SetRCChannels(MV04_JoyFlightMode.Follow);
-
                                         if (Interface.MAV.cs.mode.ToLower() != "guided")
-                                            Interface.setMode((byte)Interface.sysidcurrent, (byte)Interface.compidcurrent, "GUIDED");
+                                            Interface.setMode((byte)Interface.sysidcurrent, (byte)Interface.compidcurrent, "GUIDED", true);
 
                                         StateHandler.CurrentSate = MV04_State.Follow;
                                         break;

--- a/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
+++ b/ExtLibs/ArduPilot/Mavlink/MAVLinkInterface.cs
@@ -221,6 +221,8 @@ namespace MissionPlanner
             }
         }
 
+        public event EventHandler<SetModeEventArgs> SetModeEvent;
+
         public static byte gcssysid { get; set; } = 255;
 
         private string lastset = "";
@@ -4521,14 +4523,14 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
             setMode(MAV.sysid, MAV.compid, modein);
         }
 
-        public void setMode(byte sysid, byte compid, string modein)
+        public void setMode(byte sysid, byte compid, string modein, bool mv04_camera_mode = false)
         {
             mavlink_set_mode_t mode = new mavlink_set_mode_t();
 
             if (translateMode(sysid, compid, modein, ref mode))
             {
                 log.Info("setMode " + modein + " (" + mode.custom_mode + ")");
-                setMode(sysid, compid, mode);
+                setMode(sysid, compid, mode, 0, mv04_camera_mode);
             }
         }
 
@@ -4538,7 +4540,7 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
             setMode(MAV.sysid, MAV.compid, mode, base_mode);
         }
 
-        public void setMode(byte sysid, byte compid, mavlink_set_mode_t mode, MAV_MODE_FLAG base_mode = 0)
+        public void setMode(byte sysid, byte compid, mavlink_set_mode_t mode, MAV_MODE_FLAG base_mode = 0, bool mv04_camera_mode = false)
         {
             mode.base_mode |= (byte) base_mode;
 
@@ -4549,6 +4551,16 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
             generatePacket((byte) (byte) MAVLINK_MSG_ID.SET_MODE, mode, sysid, compid);
             Thread.Sleep(10);
             generatePacket((byte) (byte) MAVLINK_MSG_ID.SET_MODE, mode, sysid, compid);
+
+            TriggerSetModeEvent(mode, mv04_camera_mode);
+        }
+
+        public void TriggerSetModeEvent(mavlink_set_mode_t mode, bool mv04_camera_mode)
+        {
+            if (SetModeEvent != null)
+            {
+                SetModeEvent(null, new SetModeEventArgs(mode, mv04_camera_mode));
+            }
         }
 
         private double t7 = 1.0e7;
@@ -6776,6 +6788,18 @@ Mission Planner waits for 2 valid heartbeat packets before connecting");
             {
                 log.Info(progress + "% " + status);
             }
+        }
+    }
+
+    public class SetModeEventArgs : EventArgs
+    {
+        public MAVLink.mavlink_set_mode_t Mode { get; set; }
+        public bool MV04CameraMode { get; set; }
+
+        public SetModeEventArgs(MAVLink.mavlink_set_mode_t mode, bool mv04_camera_mode)
+        {
+            Mode = mode;
+            MV04CameraMode = mv04_camera_mode;
         }
     }
 }

--- a/ExtLibs/MV04.Joystick/JoystickHandler.cs
+++ b/ExtLibs/MV04.Joystick/JoystickHandler.cs
@@ -75,12 +75,10 @@ namespace MV04.Joystick
         Cam_Yaw
     }
 
-    public enum MV04_JoyFlightMode
+    public enum MV04_JoyMode
     {
-        Manual,
-        TapToFly,
-        Auto,
-        Follow
+        UAV,
+        Camera
     }
 
     #endregion
@@ -103,9 +101,9 @@ namespace MV04.Joystick
 
     public class JoystickModeChangedEventArgs: EventArgs
     {
-        public MV04_JoyFlightMode Mode { get; set; }
+        public MV04_JoyMode Mode { get; set; }
 
-        public JoystickModeChangedEventArgs(MV04_JoyFlightMode mode)
+        public JoystickModeChangedEventArgs(MV04_JoyMode mode)
         {
             Mode = mode;
         }
@@ -153,15 +151,13 @@ namespace MV04.Joystick
         /// <summary>
         /// Return a set of joystick axes paired to RC channels for the given mode
         /// </summary>
-        public static Dictionary<int, int> GetAxisSet(MV04_JoyFlightMode mode)
+        public static Dictionary<int, int> GetAxisSet(MV04_JoyMode mode)
         {
             Dictionary<int, int> result = new Dictionary<int, int>();
 
             switch (mode)
             {
-                case MV04_JoyFlightMode.TapToFly:
-                case MV04_JoyFlightMode.Auto:
-                case MV04_JoyFlightMode.Follow:
+                case MV04_JoyMode.Camera:
                     // Cam control only
                     result[1] = NoneAxis;                                       // UAV Roll
                     result[2] = NoneAxis;                                       // UAV Pitch
@@ -172,7 +168,7 @@ namespace MV04.Joystick
                     result[7] = GetAxisForJoyRole(MV04_JoyRole.UAV_Yaw);        // Cam Yaw
                     break;
                 
-                case MV04_JoyFlightMode.Manual:
+                case MV04_JoyMode.UAV:
                 default:
                     // UAV control only
                     result[1] = GetAxisForJoyRole(MV04_JoyRole.UAV_Roll);       // UAV Roll
@@ -191,7 +187,7 @@ namespace MV04.Joystick
         /// <summary>
         /// Trigger a JoystickModeChanged event with the given parameters
         /// </summary>
-        public static void TriggerJoystickModeChangedEvent(MV04_JoyFlightMode mode)
+        public static void TriggerJoystickModeChangedEvent(MV04_JoyMode mode)
         {
             if (JoystickModeChanged != null)
             {

--- a/ExtLibs/MV04.TestForms/JoystickAxisSwitcherForm.cs
+++ b/ExtLibs/MV04.TestForms/JoystickAxisSwitcherForm.cs
@@ -14,12 +14,12 @@ namespace MV04.TestForms
             InitializeComponent();
             this.joystick = joystick;
 
-            comboBox_Modes.DataSource = Enum.GetNames(typeof(MV04_JoyFlightMode));
+            comboBox_Modes.DataSource = Enum.GetNames(typeof(MV04_JoyMode));
         }
 
         private void button_Set_Click(object sender, EventArgs e)
         {
-            MV04_JoyFlightMode mode = (MV04_JoyFlightMode)comboBox_Modes.SelectedIndex;
+            MV04_JoyMode mode = (MV04_JoyMode)comboBox_Modes.SelectedIndex;
 
             if (joystick.enabled)
             {

--- a/ExtLibs/wasm/Pages/Websocket.razor
+++ b/ExtLibs/wasm/Pages/Websocket.razor
@@ -71,7 +71,7 @@
                 <button @onclick=@(async() => { await mav_mission.download(mav, mav.MAV.sysid, mav.MAV.compid, MAVLink.MAV_MISSION_TYPE.MISSION);})>Get Mission</button>
                 <button @onclick=@(async() => { await mav_mission.download(mav, mav.MAV.sysid, mav.MAV.compid, MAVLink.MAV_MISSION_TYPE.FENCE);})>Get Fence</button>
                 <button @onclick=@(async() => { await mav_mission.download(mav, mav.MAV.sysid, mav.MAV.compid, MAVLink.MAV_MISSION_TYPE.RALLY);})>Get Rally</button><br/>
-                <button @onclick=@(async() => { mav.setMode("GUIDED"); await mav.doCommandAsync(mav.MAV.sysid, mav.MAV.compid, MAVLink.MAV_CMD.TAKEOFF, 0, 0, 0, 0, 0, 0, 2); })>TakeOff - 2m</button>
+                <button @onclick=@(async() => { mav.setMode(mav.MAV.sysid, mav.MAV.compid, "GUIDED"); await mav.doCommandAsync(mav.MAV.sysid, mav.MAV.compid, MAVLink.MAV_CMD.TAKEOFF, 0, 0, 0, 0, 0, 0, 2); })>TakeOff - 2m</button>
             </div>
             <div id="serverStatus" style="width: 100%; overflow-y: auto; flex-grow: 0;"></div>
         </div>

--- a/GCSViews/FlightData.cs
+++ b/GCSViews/FlightData.cs
@@ -1399,7 +1399,7 @@ namespace MissionPlanner.GCSViews
             try
             {
                 ((Control) sender).Enabled = false;
-                MainV2.comPort.setMode("Auto");
+                MainV2.comPort.setMode(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, "Auto");
             }
             catch
             {
@@ -1418,7 +1418,7 @@ namespace MissionPlanner.GCSViews
                     MainV2.comPort.MAV.cs.firmware == Firmwares.Ateryx ||
                     MainV2.comPort.MAV.cs.firmware == Firmwares.ArduRover ||
                     MainV2.comPort.MAV.cs.firmware == Firmwares.ArduCopter2)
-                    MainV2.comPort.setMode("Loiter");
+                    MainV2.comPort.setMode(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, "Loiter");
             }
             catch
             {
@@ -1433,7 +1433,7 @@ namespace MissionPlanner.GCSViews
             try
             {
                 ((Control) sender).Enabled = false;
-                MainV2.comPort.setMode("RTL");
+                MainV2.comPort.setMode(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, "RTL");
             }
             catch
             {
@@ -1538,7 +1538,7 @@ namespace MissionPlanner.GCSViews
                         {
                             while (MainV2.comPort.MAV.cs.mode.ToLower() != "Guided".ToLower())
                             {
-                                MainV2.comPort.setMode("GUIDED");
+                                MainV2.comPort.setMode(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, "GUIDED");
                                 Thread.Sleep(1000);
                                 Application.DoEvents();
                                 timeout++;
@@ -1589,7 +1589,7 @@ namespace MissionPlanner.GCSViews
                         timeout = 0;
                         while (MainV2.comPort.MAV.cs.mode.ToLower() != "AUTO".ToLower())
                         {
-                            MainV2.comPort.setMode("AUTO");
+                            MainV2.comPort.setMode(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, "AUTO");
                             Thread.Sleep(1000);
                             Application.DoEvents();
                             timeout++;
@@ -1634,7 +1634,7 @@ namespace MissionPlanner.GCSViews
                 }
             }
 
-            MainV2.comPort.setMode(CMB_modes.Text);
+            MainV2.comPort.setMode(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, CMB_modes.Text);
         }
 
         private void BUT_calib_Click(object sender, EventArgs e)
@@ -1776,7 +1776,7 @@ namespace MissionPlanner.GCSViews
                     {
                         var custom_mode = (MainV2.comPort.MAV.cs.sensors_enabled.motor_control && MainV2.comPort.MAV.cs.sensors_enabled.seen) ? 1u : 0u;
                         var mode = new MAVLink.mavlink_set_mode_t() { custom_mode = custom_mode, target_system = (byte)MainV2.comPort.sysidcurrent };
-                        MainV2.comPort.setMode(mode, MAVLink.MAV_MODE_FLAG.SAFETY_ARMED);
+                        MainV2.comPort.setMode(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, mode, MAVLink.MAV_MODE_FLAG.SAFETY_ARMED);
                         ((Control)sender).Enabled = true;
                         return;
                     }

--- a/Script.cs
+++ b/Script.cs
@@ -148,7 +148,7 @@ namespace MissionPlanner
 
         public bool ChangeMode(string mode)
         {
-            MainV2.comPort.setMode(mode);
+            MainV2.comPort.setMode(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, mode);
             return true;
         }
 

--- a/temp.cs
+++ b/temp.cs
@@ -618,11 +618,11 @@ namespace MissionPlanner
                 float takeoffAlt = float.Parse(Settings.Instance["takeoff_alt", "10"], CultureInfo.InvariantCulture);
                 Settings.Instance["takeoff_alt"] = takeoffAlt.ToString(CultureInfo.InvariantCulture);
 
-                MainV2.comPort.setMode("Stabilize");
+                MainV2.comPort.setMode(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, "Stabilize");
 
                 if (MainV2.comPort.doARM(true))
                 {
-                    MainV2.comPort.setMode("GUIDED");
+                    MainV2.comPort.setMode(MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid, "GUIDED");
 
                     Thread.Sleep(300);
 
@@ -1189,6 +1189,7 @@ namespace MissionPlanner
         {
             if (CustomMessageBox.Show("Are you sure?", "", MessageBoxButtons.YesNo) == (int)DialogResult.Yes)
                 MainV2.comPort.setMode(
+                    MainV2.comPort.MAV.sysid, MainV2.comPort.MAV.compid,
                     new MAVLink.mavlink_set_mode_t()
                     {
                         custom_mode = (MainV2.comPort.MAV.cs.sensors_enabled.motor_control == true && MainV2.comPort.MAV.cs.sensors_enabled.seen) ? 1u : 0u,


### PR DESCRIPTION
- New joystick states: Cam, UAV
- Event based mode switching, triggered from MAVInterface setMode() calls
- Default / fallback mode is UAV
- Does not handle cases where the Autopilot switches it's flightmode internally (e.g. failsafe RTL)